### PR TITLE
Allow search query to be provided in URL query string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import fuzzysort from "fuzzysort";
 import data from "../tag-versions";
 
 const tagVersions = data.map(([version, helpTag]) => ({version, helpTag}));
+const queryString = new URLSearchParams(window.location.search);
+const search = queryString.get('q');
 const input = document.getElementById("input"),
 	results = document.getElementById("results");
 
@@ -13,5 +15,23 @@ function render() {
 		.map(result => `<tr><td>${fuzzysort.highlight(result)}</td><td>${result.obj.version}</td></tr>`)
 		.join("");
 }
+
+function updateQueryString() {
+	queryString.set('q', input.value);
+
+	const newLocation = `${window.location.pathname}?${queryString.toString()}`;
+	history.replaceState(null, '', newLocation);
+}
+
+if (search) {
+	input.value = search;
+}
+
 render();
-input.addEventListener("input", render);
+input.addEventListener(
+	"input",
+	() => {
+		render();
+		updateQueryString();
+	}
+);


### PR DESCRIPTION
Enables the search string to be passed in through the `q` query
parameter in the URL. This way, searches can be shared and bookmarked.

When the input field is changed, the query string is updated
accordingly.

For example, when searching for ":h", the URL looks like:

    http://localhost:8080/?q=%3Ah

![vim-helptags-version query string](https://user-images.githubusercontent.com/342964/135325544-35dff3e2-ca74-488d-85d0-c503743210b1.gif)


